### PR TITLE
Support source/destination IPs and ports

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,7 @@ env:
 jobs:
 
   mirror_to_gitlab:
+    if: github.event_name == 'push' && github.ref_name == 'main'
     uses: NullNet-ai/appguard-server/.github/workflows/gitlab_mirror.yml@main
     secrets:
       GITLAB_TOKEN: ${{secrets.GITLAB_TOKEN}}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,7 +3,10 @@ name: Rust
 on:
   push:
     branches:
-      - 'main'
+      - '*'
+  pull_request:
+    branches:
+      - '*'
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de45108900e1f9b9242f7f2e254aa3e2c029c921c258fe9e6b4217eeebd54288"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
  "axum-core 0.5.2",
  "bytes",
@@ -238,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -298,9 +298,9 @@ checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
 
 [[package]]
 name = "cc"
-version = "1.2.19"
+version = "1.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
+checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
 dependencies = [
  "shlex",
 ]
@@ -664,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -699,9 +699,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -724,9 +724,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "heck"
@@ -1068,7 +1068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -1139,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue"
-version = "1.0.8"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -1455,7 +1455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "736a385f5e9b456653b7eac7cf811391e64336285b2f45b4ed6779d77e4a687a"
 dependencies = [
  "async-channel",
- "axum 0.8.3",
+ "axum 0.8.4",
  "chrono",
  "etherparse",
  "futures",
@@ -1549,9 +1549,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.107"
+version = "0.9.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
 dependencies = [
  "cc",
  "libc",
@@ -1861,14 +1861,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -1954,7 +1954,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1969,7 +1969,7 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 [[package]]
 name = "rpn-predicate-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/GyulyVGC/postfix-predicate-interpreter.git?branch=appguard#93c47410253bfac6d3f8aefdc7d6620d1be99623"
+source = "git+https://github.com/GyulyVGC/postfix-predicate-interpreter.git?branch=appguard#57d455d9418ab839577948c2f25de6b1b79808cf"
 dependencies = [
  "serde",
 ]
@@ -1982,9 +1982,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags 2.9.0",
  "errno",
@@ -1995,9 +1995,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.26"
+version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "log",
  "once_cell",
@@ -2031,15 +2031,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.1"
+version = "0.103.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
+checksum = "7149975849f1abb3832b246010ef62ccc80d3a76169517ada7188252b9cfb437"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2266,9 +2269,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2286,9 +2289,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2446,9 +2449,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2497,7 +2500,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85839f0b32fd242bb3209262371d07feda6d780d16ee9d2bc88581b89da1549b"
 dependencies = [
  "async-trait",
- "axum 0.8.3",
+ "axum 0.8.4",
  "base64",
  "bytes",
  "h2",
@@ -3103,18 +3106,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,8 +59,8 @@ dependencies = [
  "nullnet-libdatastore",
  "nullnet-liberror",
  "nullnet-libipinfo",
- "nullnet-liblogging 0.2.0",
- "nullnet-libtoken 0.2.0",
+ "nullnet-liblogging",
+ "nullnet-libtoken",
  "prost",
  "reqwest",
  "rpn-predicate-interpreter",
@@ -68,26 +68,8 @@ dependencies = [
  "serde_json",
  "serial_test",
  "tokio",
- "tonic 0.13.0",
- "tonic-build 0.13.0",
-]
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "async-channel"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
+ "tonic 0.13.1",
+ "tonic-build 0.13.1",
 ]
 
 [[package]]
@@ -164,19 +146,16 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
+checksum = "de45108900e1f9b9242f7f2e254aa3e2c029c921c258fe9e6b4217eeebd54288"
 dependencies = [
  "axum-core 0.5.2",
  "bytes",
- "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
- "hyper",
- "hyper-util",
  "itoa",
  "matchit 0.8.4",
  "memchr",
@@ -185,15 +164,10 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
  "sync_wrapper",
- "tokio",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -233,14 +207,13 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -256,15 +229,6 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitflags"
@@ -291,16 +255,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
-name = "c_linked_list"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
-
-[[package]]
 name = "cc"
-version = "1.2.21"
+version = "1.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
+checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
 dependencies = [
  "shlex",
 ]
@@ -319,9 +277,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -329,15 +287,6 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -374,12 +323,6 @@ checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "ctrlc"
@@ -440,36 +383,6 @@ checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "etherparse"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14e4ac78394e3ea04edbbc412099cf54f2f52ded51efb79c466a282729399d2"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
-name = "event-listener"
-version = "5.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -594,17 +507,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
-name = "futures-macro"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,7 +527,6 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -635,38 +536,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "gcc"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-
-[[package]]
-name = "get_if_addrs"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abddb55a898d32925f3148bd281174a68eeb68bbfd9a5938a57b18f506ee4ef7"
-dependencies = [
- "c_linked_list",
- "get_if_addrs-sys",
- "libc",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "get_if_addrs-sys"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04f9fb746cf36b191c00f3ede8bde9c8e64f9f4b05ae2694a9ccf5e3f5ab48"
-dependencies = [
- "gcc",
- "libc",
-]
-
-[[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -692,16 +565,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "glob"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
-
-[[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -724,9 +591,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
@@ -1042,16 +909,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "if-addrs"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,7 +925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -1096,15 +953,6 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "ipnetwork"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "ipnetwork"
@@ -1139,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue"
-version = "1.1.1"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -1220,17 +1068,11 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "144de2546bf4846c6c84b7f76be035f7ebbc1e7d40cfb05810ba45c129508321"
 dependencies = [
- "ipnetwork 0.21.1",
+ "ipnetwork",
  "log",
  "memchr",
  "serde",
 ]
-
-[[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -1301,12 +1143,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "no-std-net"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
-
-[[package]]
 name = "notify"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,16 +1168,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
-name = "nullnet-libconfmon"
-version = "0.2.5"
+name = "nullnet-libappguard"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201ba274158cfa4d2a455a68e17381169921908d336e39d3c61ea855ae83505b"
+checksum = "74e2a6a7b2f1e0dbabc77fe1c92afaf5d7d3ff68bfd8bf9b556b58c5e58f7142"
 dependencies = [
- "bincode",
- "get_if_addrs",
- "pnet",
+ "prost",
  "serde",
  "tokio",
+ "tonic 0.13.1",
 ]
 
 [[package]]
@@ -1367,18 +1202,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nullnet-libfireparse"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d9ca57591425bd97da3626c0019836f3d72cb215266b09d0a530be157b3684"
-dependencies = [
- "base64",
- "nullnet-libconfmon",
- "roxmltree",
- "serde",
-]
-
-[[package]]
 name = "nullnet-libipinfo"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,43 +1221,16 @@ dependencies = [
 
 [[package]]
 name = "nullnet-liblogging"
-version = "0.1.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9435cae7d6737af0023d30b77874e70c4c3c8b651a1267f686ad630e1efb3393"
+checksum = "a4497b48d942fb9b481bd00910c6a9fdbb38f0eef53dee5b4019ac1167bdb761"
 dependencies = [
  "chrono",
  "log",
- "once_cell",
- "syslog",
-]
-
-[[package]]
-name = "nullnet-liblogging"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c7b4833815143e0851be05248090204e5b976180ab295fa6548a250c469292"
-dependencies = [
- "chrono",
- "log",
- "nullnet-liberror",
- "nullnet-libtoken 0.1.1",
- "nullnet-wallguard-server",
- "once_cell",
- "serde",
- "serde_json",
+ "nullnet-libappguard",
+ "nullnet-libwallguard",
  "syslog",
  "tokio",
-]
-
-[[package]]
-name = "nullnet-libtoken"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b23168f23fcd788df59efb7d3c1f7321c437038f29446b56ba3a3afc1ede0063"
-dependencies = [
- "base64",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1449,31 +1245,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "nullnet-wallguard-server"
-version = "0.2.3"
+name = "nullnet-libwallguard"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a385f5e9b456653b7eac7cf811391e64336285b2f45b4ed6779d77e4a687a"
+checksum = "5428911eea00fe0983bdbf90be5a82606d39a12a6dab5ec27d99d8bda8177e16"
 dependencies = [
- "async-channel",
- "axum 0.8.4",
- "chrono",
- "etherparse",
- "futures",
- "if-addrs",
  "log",
- "md5",
- "nullnet-libdatastore",
- "nullnet-liberror",
- "nullnet-libfireparse",
- "nullnet-liblogging 0.1.2",
- "nullnet-libtoken 0.1.1",
- "once_cell",
  "prost",
  "serde",
- "serde_json",
  "tokio",
  "tonic 0.12.3",
- "tonic-build 0.12.3",
 ]
 
 [[package]]
@@ -1549,21 +1330,15 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.108"
+version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1641,97 +1416,6 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "pnet"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "682396b533413cc2e009fbb48aadf93619a149d3e57defba19ff50ce0201bd0d"
-dependencies = [
- "ipnetwork 0.20.0",
- "pnet_base",
- "pnet_datalink",
- "pnet_packet",
- "pnet_sys",
- "pnet_transport",
-]
-
-[[package]]
-name = "pnet_base"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc190d4067df16af3aba49b3b74c469e611cad6314676eaf1157f31aa0fb2f7"
-dependencies = [
- "no-std-net",
-]
-
-[[package]]
-name = "pnet_datalink"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79e70ec0be163102a332e1d2d5586d362ad76b01cec86f830241f2b6452a7b7"
-dependencies = [
- "ipnetwork 0.20.0",
- "libc",
- "pnet_base",
- "pnet_sys",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "pnet_macros"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13325ac86ee1a80a480b0bc8e3d30c25d133616112bb16e86f712dcf8a71c863"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
- "syn",
-]
-
-[[package]]
-name = "pnet_macros_support"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed67a952585d509dd0003049b1fc56b982ac665c8299b124b90ea2bdb3134ab"
-dependencies = [
- "pnet_base",
-]
-
-[[package]]
-name = "pnet_packet"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c96ebadfab635fcc23036ba30a7d33a80c39e8461b8bd7dc7bb186acb96560f"
-dependencies = [
- "glob",
- "pnet_base",
- "pnet_macros",
- "pnet_macros_support",
-]
-
-[[package]]
-name = "pnet_sys"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d4643d3d4db6b08741050c2f3afa9a892c4244c085a72fcda93c9c2c9a00f4b"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "pnet_transport"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f604d98bc2a6591cf719b58d3203fd882bdd6bf1db696c4ac97978e9f4776bf"
-dependencies = [
- "libc",
- "pnet_base",
- "pnet_packet",
- "pnet_sys",
-]
 
 [[package]]
 name = "powerfmt"
@@ -1861,14 +1545,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -1954,22 +1638,16 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.15",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
-name = "roxmltree"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
-
-[[package]]
 name = "rpn-predicate-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/GyulyVGC/postfix-predicate-interpreter.git?branch=appguard#57d455d9418ab839577948c2f25de6b1b79808cf"
+source = "git+https://github.com/GyulyVGC/postfix-predicate-interpreter.git?branch=appguard#93c47410253bfac6d3f8aefdc7d6620d1be99623"
 dependencies = [
  "serde",
 ]
@@ -1982,9 +1660,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
  "bitflags 2.9.0",
  "errno",
@@ -1995,9 +1673,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.27"
+version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
  "log",
  "once_cell",
@@ -2031,18 +1709,15 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.12.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
-dependencies = [
- "zeroize",
-]
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.2"
+version = "0.103.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7149975849f1abb3832b246010ef62ccc80d3a76169517ada7188252b9cfb437"
+checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2169,16 +1844,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
-dependencies = [
- "itoa",
- "serde",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2222,15 +1887,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2269,9 +1925,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2289,9 +1945,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2389,17 +2045,15 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -2449,9 +2103,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2495,12 +2149,12 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85839f0b32fd242bb3209262371d07feda6d780d16ee9d2bc88581b89da1549b"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
  "async-trait",
- "axum 0.8.4",
+ "axum 0.8.3",
  "base64",
  "bytes",
  "h2",
@@ -2540,9 +2194,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85f0383fadd15609306383a90e85eaed44169f931a5d2be1b42c76ceff1825e"
+checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -2609,7 +2263,6 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2798,28 +2451,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2827,12 +2458,6 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -3106,18 +2731,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/firewall/firewall.rs
+++ b/src/firewall/firewall.rs
@@ -90,7 +90,8 @@ mod tests {
         FirewallRule, FirewallRuleCondition, FirewallRuleDirection, FirewallRuleField,
     };
     use crate::proto::appguard::{
-        AppGuardIpInfo, AppGuardSmtpRequest, AppGuardTcpConnection, AppGuardTcpInfo,
+        AppGuardHttpRequest, AppGuardIpInfo, AppGuardSmtpRequest, AppGuardTcpConnection,
+        AppGuardTcpInfo,
     };
     use rpn_predicate_interpreter::{Operator, PostfixExpression, PostfixToken};
 
@@ -226,15 +227,17 @@ mod tests {
         let content = std::fs::read_to_string("test_material/firewall_test_1.json").unwrap();
         let firewall = Firewall::from_infix(&content).unwrap();
 
-        let mut item_1 = AppGuardTcpInfo::default();
+        let mut item_1 = AppGuardHttpRequest::default();
         assert_eq!(firewall.match_item(&item_1), FirewallResult::default());
 
+        let mut tcp_info = AppGuardTcpInfo::default();
         let mut ip_info = AppGuardIpInfo::default();
         ip_info.country = Some("US".to_string());
+        tcp_info.ip_info = Some(ip_info);
         let mut tcp_connection = AppGuardTcpConnection::default();
         tcp_connection.protocol = "HTTP".to_string();
-        item_1.ip_info = Some(ip_info);
-        item_1.connection = Some(tcp_connection);
+        tcp_info.connection = Some(tcp_connection);
+        item_1.tcp_info = Some(tcp_info);
 
         assert_eq!(
             firewall.match_item(&item_1),

--- a/src/firewall/items/http_request.rs
+++ b/src/firewall/items/http_request.rs
@@ -1,6 +1,7 @@
 use crate::firewall::header_val::HeaderVal;
 use crate::firewall::rules::{
     FirewallCompareType, FirewallRule, FirewallRuleDirection, FirewallRuleField,
+    FirewallRuleWithDirection,
 };
 use crate::helpers::get_header;
 use crate::proto::appguard::{AppGuardHttpRequest, AppGuardIpInfo, AppGuardTcpInfo};
@@ -83,7 +84,10 @@ impl PredicateEvaluator for AppGuardHttpRequest {
             self.tcp_info
                 .as_ref()
                 .unwrap_or(&AppGuardTcpInfo::default())
-                .evaluate_predicate(predicate)
+                .evaluate_predicate(&FirewallRuleWithDirection {
+                    rule: predicate,
+                    direction: FirewallRuleDirection::In,
+                })
         }
     }
 

--- a/src/firewall/items/http_response.rs
+++ b/src/firewall/items/http_response.rs
@@ -1,6 +1,7 @@
 use crate::firewall::header_val::HeaderVal;
 use crate::firewall::rules::{
     FirewallCompareType, FirewallRule, FirewallRuleDirection, FirewallRuleField,
+    FirewallRuleWithDirection,
 };
 use crate::helpers::get_header;
 use crate::proto::appguard::{AppGuardHttpResponse, AppGuardIpInfo, AppGuardTcpInfo};
@@ -65,7 +66,10 @@ impl PredicateEvaluator for AppGuardHttpResponse {
             self.tcp_info
                 .as_ref()
                 .unwrap_or(&AppGuardTcpInfo::default())
-                .evaluate_predicate(predicate)
+                .evaluate_predicate(&FirewallRuleWithDirection {
+                    rule: predicate,
+                    direction: FirewallRuleDirection::Out,
+                })
         }
     }
 

--- a/src/firewall/items/ip_info.rs
+++ b/src/firewall/items/ip_info.rs
@@ -1,7 +1,7 @@
 use rpn_predicate_interpreter::PredicateEvaluator;
 use serde::{Deserialize, Serialize};
 
-use crate::firewall::rules::{FirewallCompareType, FirewallRule, FirewallRuleField};
+use crate::firewall::rules::{FirewallCompareType, FirewallRuleField, FirewallRuleWithDirection};
 use crate::proto::appguard::AppGuardIpInfo;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
@@ -72,19 +72,19 @@ impl IpInfoField {
     }
 }
 
-impl PredicateEvaluator for AppGuardIpInfo {
-    type Predicate = FirewallRule;
+impl<'a> PredicateEvaluator for &'a AppGuardIpInfo {
+    type Predicate = FirewallRuleWithDirection<'a>;
     type Reason = String;
 
     fn evaluate_predicate(&self, predicate: &Self::Predicate) -> bool {
-        if let FirewallRuleField::IpInfo(f) = &predicate.field {
-            return predicate.condition.compare(f.get_compare_fields(self));
+        if let FirewallRuleField::IpInfo(f) = &predicate.rule.field {
+            return predicate.rule.condition.compare(f.get_compare_fields(self));
         }
         false
     }
 
     fn get_reason(&self, predicate: &Self::Predicate) -> Self::Reason {
-        predicate.field.get_field_name()
+        predicate.rule.field.get_field_name()
     }
 }
 

--- a/src/firewall/items/smtp_request.rs
+++ b/src/firewall/items/smtp_request.rs
@@ -1,6 +1,7 @@
 use crate::firewall::header_val::HeaderVal;
 use crate::firewall::rules::{
     FirewallCompareType, FirewallRule, FirewallRuleDirection, FirewallRuleField,
+    FirewallRuleWithDirection,
 };
 use crate::helpers::get_header;
 use crate::proto::appguard::{AppGuardIpInfo, AppGuardSmtpRequest, AppGuardTcpInfo};
@@ -64,7 +65,10 @@ impl PredicateEvaluator for AppGuardSmtpRequest {
             self.tcp_info
                 .as_ref()
                 .unwrap_or(&AppGuardTcpInfo::default())
-                .evaluate_predicate(predicate)
+                .evaluate_predicate(&FirewallRuleWithDirection {
+                    rule: predicate,
+                    direction: FirewallRuleDirection::In,
+                })
         }
     }
 

--- a/src/firewall/items/smtp_response.rs
+++ b/src/firewall/items/smtp_response.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::firewall::rules::{
     FirewallCompareType, FirewallRule, FirewallRuleDirection, FirewallRuleField,
+    FirewallRuleWithDirection,
 };
 use crate::proto::appguard::{AppGuardIpInfo, AppGuardSmtpResponse, AppGuardTcpInfo};
 
@@ -47,7 +48,10 @@ impl PredicateEvaluator for AppGuardSmtpResponse {
             self.tcp_info
                 .as_ref()
                 .unwrap_or(&AppGuardTcpInfo::default())
-                .evaluate_predicate(predicate)
+                .evaluate_predicate(&FirewallRuleWithDirection {
+                    rule: predicate,
+                    direction: FirewallRuleDirection::Out,
+                })
         }
     }
 

--- a/src/firewall/items/tcp_connection.rs
+++ b/src/firewall/items/tcp_connection.rs
@@ -1,22 +1,28 @@
 use rpn_predicate_interpreter::PredicateEvaluator;
 use serde::{Deserialize, Serialize};
 
-use crate::firewall::rules::{FirewallCompareType, FirewallRule, FirewallRuleField};
+use crate::firewall::rules::{
+    FirewallCompareType, FirewallRuleDirection, FirewallRuleField, FirewallRuleWithDirection,
+};
 use crate::proto::appguard::AppGuardTcpConnection;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum TcpConnectionField {
-    Ip(Vec<String>),
-    Port(Vec<u32>),
+    SourceIp(Vec<String>),
+    DestinationIp(Vec<String>),
+    SourcePort(Vec<u32>),
+    DestinationPort(Vec<u32>),
     Protocol(Vec<String>),
 }
 
 impl TcpConnectionField {
     pub fn get_field_name(&self) -> &str {
         match self {
-            TcpConnectionField::Ip(_) => "ip",
-            TcpConnectionField::Port(_) => "port",
+            TcpConnectionField::SourceIp(_) => "source_ip",
+            TcpConnectionField::DestinationIp(_) => "destination_ip",
+            TcpConnectionField::SourcePort(_) => "source_port",
+            TcpConnectionField::DestinationPort(_) => "destination_port",
             TcpConnectionField::Protocol(_) => "protocol",
         }
     }
@@ -24,16 +30,29 @@ impl TcpConnectionField {
     fn get_compare_fields<'a>(
         &'a self,
         item: &'a AppGuardTcpConnection,
+        direction: &FirewallRuleDirection,
     ) -> Option<FirewallCompareType<'a>> {
         match self {
-            TcpConnectionField::Ip(v) => item
-                .source_ip
-                .as_ref()
-                .map(|ip| FirewallCompareType::String((ip, v))),
-            TcpConnectionField::Port(v) => item
-                .source_port
-                .as_ref()
-                .map(|port| FirewallCompareType::U32((*port, v))),
+            TcpConnectionField::SourceIp(v) => match direction {
+                FirewallRuleDirection::In => item.source_ip.as_ref(),
+                FirewallRuleDirection::Out => item.destination_ip.as_ref(),
+            }
+            .map(|ip| FirewallCompareType::String((ip, v))),
+            TcpConnectionField::DestinationIp(v) => match direction {
+                FirewallRuleDirection::In => item.destination_ip.as_ref(),
+                FirewallRuleDirection::Out => item.source_ip.as_ref(),
+            }
+            .map(|ip| FirewallCompareType::String((ip, v))),
+            TcpConnectionField::SourcePort(v) => match direction {
+                FirewallRuleDirection::In => item.source_port,
+                FirewallRuleDirection::Out => item.destination_port,
+            }
+            .map(|p| FirewallCompareType::U32((p, v))),
+            TcpConnectionField::DestinationPort(v) => match direction {
+                FirewallRuleDirection::In => item.destination_port,
+                FirewallRuleDirection::Out => item.source_port,
+            }
+            .map(|p| FirewallCompareType::U32((p, v))),
             TcpConnectionField::Protocol(v) => {
                 Some(FirewallCompareType::String((&item.protocol, v)))
             }
@@ -41,19 +60,22 @@ impl TcpConnectionField {
     }
 }
 
-impl PredicateEvaluator for AppGuardTcpConnection {
-    type Predicate = FirewallRule;
+impl<'a> PredicateEvaluator for &'a AppGuardTcpConnection {
+    type Predicate = FirewallRuleWithDirection<'a>;
     type Reason = String;
 
     fn evaluate_predicate(&self, predicate: &Self::Predicate) -> bool {
-        if let FirewallRuleField::TcpConnection(f) = &predicate.field {
-            return predicate.condition.compare(f.get_compare_fields(self));
+        if let FirewallRuleField::TcpConnection(f) = &predicate.rule.field {
+            return predicate
+                .rule
+                .condition
+                .compare(f.get_compare_fields(self, &predicate.direction));
         }
         false
     }
 
     fn get_reason(&self, predicate: &Self::Predicate) -> Self::Reason {
-        predicate.field.get_field_name()
+        predicate.rule.field.get_field_name()
     }
 }
 
@@ -74,26 +96,73 @@ mod tests {
     }
 
     #[test]
-    fn test_tcp_connection_get_ip() {
+    fn test_tcp_connection_get_source_ip() {
         let tcp_connection = sample_tcp_connection();
-        let tcp_connection_field = TcpConnectionField::Ip(vec!["8.8.8.8".to_string()]);
-        assert_eq!(
-            tcp_connection_field.get_compare_fields(&tcp_connection),
-            Some(FirewallCompareType::String((
-                &"1.1.1.1".to_string(),
-                &vec!["8.8.8.8".to_string()]
-            )))
-        );
+        let tcp_connection_field = TcpConnectionField::SourceIp(vec!["8.8.8.8".to_string()]);
+        for direction in [FirewallRuleDirection::In, FirewallRuleDirection::In].iter() {
+            let ip = match direction {
+                FirewallRuleDirection::In => "1.1.1.1",
+                FirewallRuleDirection::Out => "2.2.2.2",
+            };
+            assert_eq!(
+                tcp_connection_field.get_compare_fields(&tcp_connection, &direction),
+                Some(FirewallCompareType::String((
+                    &ip.to_string(),
+                    &vec!["8.8.8.8".to_string()]
+                )))
+            );
+        }
     }
 
     #[test]
-    fn test_tcp_connection_get_port() {
+    fn test_tcp_connection_get_destination_ip() {
         let tcp_connection = sample_tcp_connection();
-        let tcp_connection_field = TcpConnectionField::Port(vec![80, 443, 8080]);
-        assert_eq!(
-            tcp_connection_field.get_compare_fields(&tcp_connection),
-            Some(FirewallCompareType::U32((1234, &vec![80, 443, 8080])))
-        );
+        let tcp_connection_field = TcpConnectionField::DestinationIp(vec!["8.8.8.8".to_string()]);
+        for direction in [FirewallRuleDirection::In, FirewallRuleDirection::In].iter() {
+            let ip = match direction {
+                FirewallRuleDirection::In => "2.2.2.2",
+                FirewallRuleDirection::Out => "1.1.1.1",
+            };
+            assert_eq!(
+                tcp_connection_field.get_compare_fields(&tcp_connection, &direction),
+                Some(FirewallCompareType::String((
+                    &ip.to_string(),
+                    &vec!["8.8.8.8".to_string()]
+                )))
+            );
+        }
+    }
+
+    #[test]
+    fn test_tcp_connection_get_source_port() {
+        let tcp_connection = sample_tcp_connection();
+        let tcp_connection_field = TcpConnectionField::SourcePort(vec![8080]);
+        for direction in [FirewallRuleDirection::In, FirewallRuleDirection::In].iter() {
+            let p = match direction {
+                FirewallRuleDirection::In => 1234,
+                FirewallRuleDirection::Out => 5678,
+            };
+            assert_eq!(
+                tcp_connection_field.get_compare_fields(&tcp_connection, &direction),
+                Some(FirewallCompareType::U32((p, &vec![8080])))
+            );
+        }
+    }
+
+    #[test]
+    fn test_tcp_connection_get_destination_port() {
+        let tcp_connection = sample_tcp_connection();
+        let tcp_connection_field = TcpConnectionField::DestinationPort(vec![8080]);
+        for direction in [FirewallRuleDirection::In, FirewallRuleDirection::In].iter() {
+            let p = match direction {
+                FirewallRuleDirection::In => 5678,
+                FirewallRuleDirection::Out => 1234,
+            };
+            assert_eq!(
+                tcp_connection_field.get_compare_fields(&tcp_connection, &direction),
+                Some(FirewallCompareType::U32((p, &vec![8080])))
+            );
+        }
     }
 
     #[test]
@@ -101,12 +170,14 @@ mod tests {
         let tcp_connection = sample_tcp_connection();
         let tcp_connection_field =
             TcpConnectionField::Protocol(vec!["SMTP".to_string(), "ESMTP".to_string()]);
-        assert_eq!(
-            tcp_connection_field.get_compare_fields(&tcp_connection),
-            Some(FirewallCompareType::String((
-                &"HTTP".to_string(),
-                &vec!["SMTP".to_string(), "ESMTP".to_string()]
-            )))
-        );
+        for direction in [FirewallRuleDirection::In, FirewallRuleDirection::In].iter() {
+            assert_eq!(
+                tcp_connection_field.get_compare_fields(&tcp_connection, direction),
+                Some(FirewallCompareType::String((
+                    &"HTTP".to_string(),
+                    &vec!["SMTP".to_string(), "ESMTP".to_string()]
+                )))
+            );
+        }
     }
 }

--- a/src/firewall/items/tcp_info.rs
+++ b/src/firewall/items/tcp_info.rs
@@ -1,14 +1,14 @@
 use rpn_predicate_interpreter::PredicateEvaluator;
 
-use crate::firewall::rules::{FirewallRule, FirewallRuleField};
+use crate::firewall::rules::{FirewallRuleField, FirewallRuleWithDirection};
 use crate::proto::appguard::{AppGuardIpInfo, AppGuardTcpConnection, AppGuardTcpInfo};
 
-impl PredicateEvaluator for AppGuardTcpInfo {
-    type Predicate = FirewallRule;
+impl<'a> PredicateEvaluator for &'a AppGuardTcpInfo {
+    type Predicate = FirewallRuleWithDirection<'a>;
     type Reason = String;
 
     fn evaluate_predicate(&self, predicate: &Self::Predicate) -> bool {
-        match &predicate.field {
+        match &predicate.rule.field {
             FirewallRuleField::TcpConnection(_) => self
                 .connection
                 .as_ref()
@@ -24,6 +24,6 @@ impl PredicateEvaluator for AppGuardTcpInfo {
     }
 
     fn get_reason(&self, predicate: &Self::Predicate) -> Self::Reason {
-        predicate.field.get_field_name()
+        predicate.rule.field.get_field_name()
     }
 }

--- a/src/firewall/rules.rs
+++ b/src/firewall/rules.rs
@@ -34,6 +34,11 @@ pub enum FirewallRuleDirection {
     Out,
 }
 
+pub struct FirewallRuleWithDirection<'a> {
+    pub(crate) rule: &'a FirewallRule,
+    pub(crate) direction: FirewallRuleDirection,
+}
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(untagged)]
 pub enum FirewallRuleField {


### PR DESCRIPTION
Support specifying both source and destination IPs and ports for firewall rules.
Particular care was needed since we need to keep into account the rule directionality to correctly determine sources and destinations.
For this reason, the `PredicateEvaluator` trait implementation for `AppGuardTcpConnection` now features a `Predicate` type including the traffic direction (incoming for requests, outgoing for responses.